### PR TITLE
fixed itempipes

### DIFF
--- a/assets/blocks/basicPipe.block
+++ b/assets/blocks/basicPipe.block
@@ -2,6 +2,9 @@
     "displayName": "Pipe Cable",
     "family": "pipe",
     "translucent": true,
+    "entity": {
+         "keepActive": true
+    },
     "no_connections": {
         "shape": "ItemPipes:NoCon",
         "entity": {

--- a/src/main/java/org/terasology/itempipes/action/InventoryInsertAction.java
+++ b/src/main/java/org/terasology/itempipes/action/InventoryInsertAction.java
@@ -37,14 +37,14 @@ public class InventoryInsertAction extends BaseComponentSystem {
     EntityManager entityManager;
 
     @ReceiveEvent
-    public void onInvetoryInsert( PipeInsertEvent event,EntityRef entityRef, InventoryComponent inventoryComponent) {
-       if(inventoryManager.giveItem(entityRef,EntityRef.NULL,event.getActor())){
-           ItemComponent itemComponent = event.getActor().getComponent(ItemComponent.class);
-           if (itemComponent != null) {
-               for (Component component : itemComponent.pickupPrefab.iterateComponents()) {
-                   event.getActor().removeComponent(component.getClass());
-               }
-           }
-       }
+    public void onInvetoryInsert(PipeInsertEvent event, EntityRef entityRef, InventoryComponent inventoryComponent) {
+        if (inventoryManager.giveItem(entityRef, EntityRef.NULL, event.getActor())) {
+            ItemComponent itemComponent = event.getActor().getComponent(ItemComponent.class);
+            if (itemComponent != null) {
+                for (Component component : itemComponent.pickupPrefab.iterateComponents()) {
+                    event.getActor().removeComponent(component.getClass());
+                }
+            }
+        }
     }
 }

--- a/src/main/java/org/terasology/itempipes/blocks/PipeBlockFamily.java
+++ b/src/main/java/org/terasology/itempipes/blocks/PipeBlockFamily.java
@@ -15,6 +15,9 @@
  */
 package org.terasology.itempipes.blocks;
 
+import com.google.common.collect.Sets;
+import gnu.trove.map.TByteObjectMap;
+import gnu.trove.map.hash.TByteObjectHashMap;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.itempipes.components.PipeComponent;
 import org.terasology.itempipes.components.PipeConnectionComponent;
@@ -22,6 +25,8 @@ import org.terasology.math.Rotation;
 import org.terasology.math.Side;
 import org.terasology.math.SideBitFlag;
 import org.terasology.math.geom.Vector3i;
+import org.terasology.naming.Name;
+import org.terasology.segmentedpaths.blocks.PathFamily;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockBuilderHelper;
 import org.terasology.world.block.BlockUri;
@@ -33,11 +38,11 @@ import org.terasology.world.block.loader.BlockFamilyDefinition;
 import org.terasology.world.block.shapes.BlockShape;
 
 import java.util.EnumSet;
+import java.util.Set;
 
 @RegisterBlockFamily("pipe")
 @BlockSections({"no_connections", "one_connection", "line_connection", "2d_corner", "3d_corner", "2d_t", "cross", "3d_side", "five_connections", "all"})
-public class PipeBlockFamily extends MultiConnectFamily {
-
+public class PipeBlockFamily extends MultiConnectFamily implements PathFamily {
     public static final String NO_CONNECTIONS = "no_connections";
     public static final String ONE_CONNECTION = "one_connection";
     public static final String TWO_CONNECTIONS_LINE = "line_connection";
@@ -49,6 +54,9 @@ public class PipeBlockFamily extends MultiConnectFamily {
     public static final String FIVE_CONNECTIONS = "five_connections";
     public static final String SIX_CONNECTIONS = "all";
 
+    private TByteObjectMap<Rotation> rotationMap = new TByteObjectHashMap<>();
+
+
     public PipeBlockFamily(BlockFamilyDefinition definition, BlockShape shape, BlockBuilderHelper blockBuilder) {
         super(definition, shape, blockBuilder);
     }
@@ -58,20 +66,19 @@ public class PipeBlockFamily extends MultiConnectFamily {
 
         BlockUri blockUri = new BlockUri(definition.getUrn());
 
-        this.registerBlock(blockUri,definition,blockBuilder,NO_CONNECTIONS, (byte)0, Rotation.allValues());
-        this.registerBlock(blockUri,definition,blockBuilder,ONE_CONNECTION, SideBitFlag.getSides(Side.BACK), Rotation.allValues());
-        this.registerBlock(blockUri,definition,blockBuilder,TWO_CONNECTIONS_LINE, SideBitFlag.getSides(Side.BACK, Side.FRONT), Rotation.allValues());
-        this.registerBlock(blockUri,definition,blockBuilder,TWO_CONNECTIONS_CORNER, SideBitFlag.getSides(Side.LEFT, Side.BACK), Rotation.allValues());
-        this.registerBlock(blockUri,definition,blockBuilder,THREE_CONNECTIONS_CORNER, SideBitFlag.getSides(Side.LEFT, Side.BACK, Side.TOP), Rotation.allValues());
-        this.registerBlock(blockUri,definition,blockBuilder,THREE_CONNECTIONS_T,  SideBitFlag.getSides(Side.LEFT, Side.BACK, Side.FRONT), Rotation.allValues());
-        this.registerBlock(blockUri,definition,blockBuilder,FOUR_CONNECTIONS_CROSS,SideBitFlag.getSides(Side.RIGHT, Side.LEFT, Side.BACK, Side.FRONT), Rotation.allValues());
-        this.registerBlock(blockUri,definition,blockBuilder,FOUR_CONNECTIONS_SIDE,  SideBitFlag.getSides(Side.LEFT, Side.BACK, Side.FRONT, Side.TOP), Rotation.allValues());
-        this.registerBlock(blockUri,definition,blockBuilder,FIVE_CONNECTIONS, SideBitFlag.getSides(Side.LEFT, Side.BACK, Side.FRONT, Side.TOP, Side.BOTTOM), Rotation.allValues());
-        this.registerBlock(blockUri,definition,blockBuilder,SIX_CONNECTIONS, SideBitFlag.getSides(Side.LEFT, Side.BACK, Side.FRONT, Side.TOP, Side.BOTTOM,Side.RIGHT), Rotation.allValues());
+        this.registerBlock(blockUri, definition, blockBuilder, NO_CONNECTIONS, (byte) 0, Rotation.allValues());
+        this.registerBlock(blockUri, definition, blockBuilder, ONE_CONNECTION, SideBitFlag.getSides(Side.BACK), Rotation.allValues());
+        this.registerBlock(blockUri, definition, blockBuilder, TWO_CONNECTIONS_LINE, SideBitFlag.getSides(Side.BACK, Side.FRONT), Rotation.allValues());
+        this.registerBlock(blockUri, definition, blockBuilder, TWO_CONNECTIONS_CORNER, SideBitFlag.getSides(Side.LEFT, Side.BACK), Rotation.allValues());
+        this.registerBlock(blockUri, definition, blockBuilder, THREE_CONNECTIONS_CORNER, SideBitFlag.getSides(Side.LEFT, Side.BACK, Side.TOP), Rotation.allValues());
+        this.registerBlock(blockUri, definition, blockBuilder, THREE_CONNECTIONS_T, SideBitFlag.getSides(Side.LEFT, Side.BACK, Side.FRONT), Rotation.allValues());
+        this.registerBlock(blockUri, definition, blockBuilder, FOUR_CONNECTIONS_CROSS, SideBitFlag.getSides(Side.RIGHT, Side.LEFT, Side.BACK, Side.FRONT), Rotation.allValues());
+        this.registerBlock(blockUri, definition, blockBuilder, FOUR_CONNECTIONS_SIDE, SideBitFlag.getSides(Side.LEFT, Side.BACK, Side.FRONT, Side.TOP), Rotation.allValues());
+        this.registerBlock(blockUri, definition, blockBuilder, FIVE_CONNECTIONS, SideBitFlag.getSides(Side.LEFT, Side.BACK, Side.FRONT, Side.TOP, Side.BOTTOM), Rotation.allValues());
+        this.registerBlock(blockUri, definition, blockBuilder, SIX_CONNECTIONS, SideBitFlag.getSides(Side.LEFT, Side.BACK, Side.FRONT, Side.TOP, Side.BOTTOM, Side.RIGHT), Rotation.allValues());
     }
 
-    public EnumSet<Side> getSides(BlockUri blockUri)
-    {
+    public EnumSet<Side> getSides(BlockUri blockUri) {
         if (getURI().equals(blockUri.getFamilyUri())) {
             try {
                 byte connections = Byte.parseByte(blockUri.getIdentifier().toString());
@@ -86,8 +93,25 @@ public class PipeBlockFamily extends MultiConnectFamily {
 
     @Override
     public byte getConnectionSides() {
-        return SideBitFlag.getSides(Side.LEFT, Side.BACK, Side.FRONT, Side.TOP, Side.BOTTOM,Side.RIGHT);
+        return SideBitFlag.getSides(Side.LEFT, Side.BACK, Side.FRONT, Side.TOP, Side.BOTTOM, Side.RIGHT);
     }
+
+    @Override
+    public Set<Block> registerBlock(BlockUri root, BlockFamilyDefinition definition, BlockBuilderHelper blockBuilder, String name, byte sides, Iterable<Rotation> rotations) {
+        Set<Block> result = Sets.newLinkedHashSet();
+        for (Rotation rotation : rotations) {
+            byte sideBits = 0;
+            for (Side side : SideBitFlag.getSides(sides)) {
+                sideBits += SideBitFlag.getSide(rotation.rotate(side));
+            }
+            Block block = blockBuilder.constructTransformedBlock(definition, name, rotation, new BlockUri(root, new Name(String.valueOf(sideBits))), this);
+            rotationMap.put(sideBits, rotation);
+            blocks.put(sideBits, block);
+            result.add(block);
+        }
+        return result;
+    }
+
 
     @Override
     protected boolean connectionCondition(Vector3i blockLocation, Side connectSide) {
@@ -101,7 +125,19 @@ public class PipeBlockFamily extends MultiConnectFamily {
 
     @Override
     public Block getArchetypeBlock() {
-        return blocks.get((byte)0);
+        return blocks.get((byte) 0);
     }
 
+    @Override
+    public Rotation getRotationFor(BlockUri blockUri) {
+        if (getURI().equals(blockUri.getFamilyUri())) {
+            try {
+                byte connections = Byte.parseByte(blockUri.getIdentifier().toString());
+                return rotationMap.get(connections);
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
+        }
+        return null;
+    }
 }

--- a/src/main/java/org/terasology/itempipes/blocks/PipeBlockSegmentMapper.java
+++ b/src/main/java/org/terasology/itempipes/blocks/PipeBlockSegmentMapper.java
@@ -68,10 +68,10 @@ public class PipeBlockSegmentMapper implements SegmentMapping {
             BlockMappingComponent blockMappingComponent = meta.prefab.getComponent(BlockMappingComponent.class);
             if (blockFamily instanceof PathFamily) {
 
-                Rotation rotation = ((PathFamily) blockFamily).getRotationFor(blockComponent.getBlock().getURI());
+                Rotation rotation = ((PathFamily) blockFamily).getRotationFor(blockComponent.block.getURI());
                 switch (ends) {
                     case START: {
-                        Vector3i segment = new Vector3i(blockComponent.getPosition()).add(rotation.rotate(blockMappingComponent.s1).getVector3i());
+                        Vector3i segment = new Vector3i(blockComponent.position).add(rotation.rotate(blockMappingComponent.s1).getVector3i());
                         EntityRef blockEntity = blockEntityRegistry.getBlockEntityAt(segment);
                         PathDescriptorComponent pathDescriptor = blockEntity.getComponent(PathDescriptorComponent.class);
                         if (pathDescriptor == null)
@@ -102,7 +102,7 @@ public class PipeBlockSegmentMapper implements SegmentMapping {
 
                     }
                     case END: {
-                        Vector3i segment = new Vector3i(blockComponent.getPosition()).add(rotation.rotate(blockMappingComponent.s2).getVector3i());
+                        Vector3i segment = new Vector3i(blockComponent.position).add(rotation.rotate(blockMappingComponent.s2).getVector3i());
                         EntityRef blockEntity = blockEntityRegistry.getBlockEntityAt(segment);
                         PathDescriptorComponent pathDescriptor = blockEntity.getComponent(PathDescriptorComponent.class);
                         if (pathDescriptor == null)

--- a/src/main/java/org/terasology/itempipes/controllers/BlockMotionSystem.java
+++ b/src/main/java/org/terasology/itempipes/controllers/BlockMotionSystem.java
@@ -84,11 +84,11 @@ public class BlockMotionSystem extends BaseComponentSystem implements UpdateSubs
                 locationComponent.setWorldPosition(position);
             } else {
                 BlockComponent blockComponent = blockEntity.getComponent(BlockComponent.class);
-                BlockFamily blockFamily = blockComponent.getBlock().getBlockFamily();
+                BlockFamily blockFamily = blockComponent.block.getBlockFamily();
                 BlockMappingComponent blockMappingComponent = pathFollowingComponent.segmentMeta.prefab.getComponent(BlockMappingComponent.class);
                 if (blockFamily instanceof PathFamily) {
                     Rotation rotation = ((PathFamily) blockFamily).getRotationFor(blockComponent.getBlock().getURI());
-                    Vector3i position = new Vector3i(blockComponent.getPosition());
+                    Vector3i position = new Vector3i(blockComponent.position);
                     if (pathFollowingComponent.segmentMeta.sign == 1) {
                         position.add(rotation.rotate(blockMappingComponent.s2).getVector3i());
                     } else {

--- a/src/main/java/org/terasology/itempipes/controllers/PipeSystem.java
+++ b/src/main/java/org/terasology/itempipes/controllers/PipeSystem.java
@@ -168,7 +168,7 @@ public class PipeSystem extends BaseComponentSystem {
         BlockComponent blockComponent = pipe.getComponent(BlockComponent.class);
         if (blockComponent == null)
             return false;
-        Block block = blockComponent.getBlock();
+        Block block = blockComponent.block;
         BlockFamily family = block.getBlockFamily();
         if (family instanceof PathFamily) {
             BlockMappingComponent blockMappingComponent = prefab.getComponent(BlockMappingComponent.class);


### PR DESCRIPTION
Itempipes couldn't work out block rotation so pipes failed to insert and the association between the transported item and the associated pipe is not persisted. 