### PR TITLE
migrate test cases to use MTEExtension

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -7,7 +7,7 @@
     "serverSideOnly": false,
     "dependencies": [
         { "id": "CoreAdvancedAssets", "minVersion": "1.1.0" },
-        { "id": "Health", "minVersion": "1.0.1", "optional": true, "because": "tests"},
+        { "id": "Health", "minVersion": "1.0.1", "optional": true},
         { "id": "Inventory", "minVersion": "1.1.0" },
         { "id": "ModuleTestingEnvironment", "minVersion": "0.2.0", "optional": true },
         { "id": "SegmentedPaths", "minVersion": "1.0.0" }

--- a/src/test/java/org/terasology/itempipes/ItemPipesTest.java
+++ b/src/test/java/org/terasology/itempipes/ItemPipesTest.java
@@ -93,8 +93,10 @@ public class ItemPipesTest {
 
     @Test
     public void connectionTest() {
-        placePipe(new Vector3i());
-        Assertions.assertEquals(0, getConn(new Vector3i()));
+        Vector3ic pipeLocation = new Vector3i(0, 0, 0);
+
+        placePipe(pipeLocation);
+        Assertions.assertEquals(0, getConn(new Vector3i(pipeLocation)));
 
         //begin with 1 to omit the pipe without connections.
         for (byte connections = 1; connections < 64; connections++) {

--- a/src/test/java/org/terasology/itempipes/ItemPipesTest.java
+++ b/src/test/java/org/terasology/itempipes/ItemPipesTest.java
@@ -114,23 +114,24 @@ public class ItemPipesTest {
 
     @Test
     public void chestInputTest() {
+        Vector3ic left = Direction.LEFT.asVector3i();
+        Vector3ic center = new Vector3i();
+        Vector3ic rChest = Direction.RIGHT.asVector3i();
 
-        placePipe(Direction.LEFT.asVector3i());
-        placePipe(new Vector3i());
-        placeChest(Direction.RIGHT.asVector3i());
+        placePipe(left);
+        placePipe(center);
+        placeChest(rChest);
 
-        EntityRef droppedItem =
-            dropBlockItem(new Vector3f(Direction.LEFT.asVector3f()).add(Direction.UP.asVector3f()), "ItemPipes" +
-                ":suction");
+        EntityRef droppedItem = dropBlockItem(new Vector3f(Direction.LEFT.asVector3f()).add(Direction.UP.asVector3f()), "ItemPipes:suction");
 
-        EntityRef startPipe = blockEntityRegistry.getBlockEntityAt(new Vector3i());
+        EntityRef startPipe = blockEntityRegistry.getBlockEntityAt(left);
         Prefab pathPrefab = pipeSystem.findingMatchingPathPrefab(startPipe, Side.RIGHT).iterator().next();
         pipeSystem.insertIntoPipe(droppedItem, startPipe, Side.RIGHT, pathPrefab, 1f);
 
         final long nextCheck = time.getGameTimeInMs() + 3000;
         helper.runWhile(() -> time.getGameTimeInMs() < nextCheck);
 
-        EntityRef chestEntity = blockEntityRegistry.getBlockEntityAt(Direction.RIGHT.asVector3i());
+        EntityRef chestEntity = blockEntityRegistry.getBlockEntityAt(rChest);
         InventoryComponent inventory = chestEntity.getComponent(InventoryComponent.class);
 
         boolean foundDroppedItem = false;
@@ -200,7 +201,7 @@ public class ItemPipesTest {
 
         worldProvider.setBlock(location,
             itemPipesBlockFamily.getBlockForPlacement(new BlockPlacementData(location, Side.FRONT,
-                new org.joml.Vector3f())));
+                new Vector3f())));
     }
 
     private void placeChest(Vector3ic location) {
@@ -208,7 +209,7 @@ public class ItemPipesTest {
 
         worldProvider.setBlock(location,
             chestFamily.getBlockForPlacement(new BlockPlacementData(location, Side.FRONT,
-                new org.joml.Vector3f())));
+                new Vector3f())));
     }
 
 
@@ -223,7 +224,7 @@ public class ItemPipesTest {
         BlockItemFactory blockItemFactory = new BlockItemFactory(entityManager);
         EntityRef newBlock = blockItemFactory.newInstance(blockFamily);
 
-        newBlock.send(new DropItemEvent(new Vector3f(location)));
+        newBlock.send(new DropItemEvent(location));
 
         return newBlock;
     }

--- a/src/test/java/org/terasology/itempipes/ItemPipesTest.java
+++ b/src/test/java/org/terasology/itempipes/ItemPipesTest.java
@@ -106,7 +106,7 @@ public class ItemPipesTest {
                 placePipe(side.direction());
             }
 
-            assertEquals(getConn(new Vector3i()), connections);
+            assertEquals(getConn(new Vector3i(pipeLocation)), connections);
 
             for (Side side : sideSet) {
                 dealDamageOn(side.direction(), 10000);


### PR DESCRIPTION
Here is a migration of the test cases to use MTTExtension. I still want to do this better but this works a lot better then where this was originally.

this PR is needed addresses a problem with the placement logic: https://github.com/MovingBlocks/Terasology/pull/4352

